### PR TITLE
add no-database-history flag

### DIFF
--- a/backup/database.go
+++ b/backup/database.go
@@ -16,7 +16,7 @@ import (
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
-func BackupDB() {
+func BackupDB(noFileTimestamp bool) {
 	log.Println("Backing up the database itself")
 
 	key := DBKey()               // before shutdown since it's saved in the db
@@ -61,7 +61,13 @@ func BackupDB() {
 	log.Println("Decrypt and decompress paranoia verification succeeded")
 	// </paranoia>
 
-	name := "db-backup-" + strconv.FormatInt(now, 10)
+	var name string
+	if !noFileTimestamp {
+		name = "db-backup-" + strconv.FormatInt(now, 10)
+	} else {
+		// old database will be overwritten
+		name = "db-backup"
+	}
 	for _, s := range storages {
 		s.UploadDatabaseBackup(enc, name)
 	}

--- a/main.go
+++ b/main.go
@@ -62,10 +62,16 @@ func main() {
 		{
 			Name:  "backup",
 			Usage: "backup a directory (or file)",
-			Flags: []cli.Flag{&cli.BoolFlag{
-				Name:  "no-backup-database",
-				Usage: "do not upload the database",
-			}},
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "no-backup-database",
+					Usage: "do not upload the database",
+				},
+				&cli.BoolFlag{
+					Name:  "no-database-history",
+					Usage: "upload the database without timestamp appended to the file name",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				if len(storage.GetAll()) == 0 {
 					return errors.New("make a storage first")
@@ -77,7 +83,7 @@ func main() {
 				paths := append([]string{c.Args().First()}, c.Args().Tail()...) // even if no argument (like: "gb backup"), backup current directory by passing one empty string arg
 				backup.Backup(paths, ch)
 				if !c.Bool("no-backup-database") {
-					backup.BackupDB()
+					backup.BackupDB(c.Bool("no-database-history"))
 				}
 				return nil
 			},


### PR DESCRIPTION
frequent automatic backups of skycache data has been causing the bucket to grow to be way bigger than necessary and I don't need the redundancy