### PR TITLE
restore deleted files too

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,6 +285,10 @@ func main() {
 					Name:  "at, to, timestamp",
 					Usage: "timestamp to which this should be restored",
 				},
+				cli.BoolFlag{
+					Name:  "latest",
+					Usage: "restore latest backup",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				timestamp, err := parseTimestamp(c.String("at"))
@@ -292,7 +296,7 @@ func main() {
 					return err
 				}
 				// restore prints out the timestamp for confirmation, no need to do it twice
-				download.Restore(c.Args().Get(0), c.Args().Get(1), timestamp)
+				download.Restore(c.Args().Get(0), c.Args().Get(1), timestamp, c.Bool("latest"))
 				return nil
 			},
 		},


### PR DESCRIPTION
context:
`mkdir foo/, mkdir foo/bar/, touch foo/bar/file`
`gb backup foo/`
`rm -r foo/bar/`
`gb backup foo/`
 
now:
`gb restore foo/bar/` will fail without timestamp provided, even though it's pretty clear (?) what gb should restore - namely the last version of `bar/`

This is just a proof of concept of what a solution might look like.
