### PR TITLE
Streaming database compression, encryption, mac, and upload

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -120,39 +120,44 @@ func Compress(path string, out io.Writer, in io.Reader, hs *utils.HasherSizer) s
 			} else {
 				read = in
 			}
-
-			pR, pW := io.Pipe()
-			verify := utils.NewSHA256HasherSizer()
-			done := make(chan struct{})
-			go func() {
-				decom := c.Decompress(pR)
-				defer decom.Close()
-				utils.Copy(&verify, decom) // this only returns once decom is EOF, which only happens strictly after pW.Close(), so this is correct
-				done <- struct{}{}
-			}()
-
-			out = io.MultiWriter(out, pW)
-			// wow infallible compression is so much easier wow
-			bufout := bufio.NewWriterSize(out, 128*1024) // 128kb, because zstd sometimes writes in small chunks
-			err := c.Compress(bufout, read)
-			if err != nil {
-				log.Println("you are infallible you cannot fail :cry:")
-				panic(err)
-			}
-			err = bufout.Flush()
-			if err != nil {
-				panic(err)
-			}
-			pW.Close()
-			<-done
-			if !bytes.Equal(verify.Hash(), hs.Hash()) {
-				log.Println(verify.Hash(), verify.Size(), hs.Hash(), hs.Size())
-				panic("compression CLAIMED it succeeded but decompressed to DIFFERENT DATA this is VERY BAD")
-			}
+			VerifiedCompression(c, out, read, hs)
 			log.Println("Compression verified")
 
 			return c.AlgName()
 		}
 	}
 	panic("this should never happen, at least NoCompression should run on every possible file")
+}
+
+// compress data while also verifying that the stream will decompress back to the same data
+// but without buffering - do the whole thing streaming
+func VerifiedCompression(c Compression, out io.Writer, read io.Reader, hs *utils.HasherSizer) {
+	pR, pW := io.Pipe()
+	verify := utils.NewSHA256HasherSizer()
+	done := make(chan struct{})
+	go func() {
+		decom := c.Decompress(pR)
+		defer decom.Close()
+		utils.Copy(&verify, decom) // this only returns once decom is EOF, which only happens strictly after pW.Close(), so this is correct
+		done <- struct{}{}
+	}()
+
+	out = io.MultiWriter(out, pW)
+	// wow infallible compression is so much easier wow
+	bufout := bufio.NewWriterSize(out, 128*1024) // 128kb, because zstd sometimes writes in small chunks
+	err := c.Compress(bufout, read)
+	if err != nil {
+		log.Println("you are infallible you cannot fail :cry:")
+		panic(err)
+	}
+	err = bufout.Flush()
+	if err != nil {
+		panic(err)
+	}
+	pW.Close()
+	<-done
+	if !bytes.Equal(verify.Hash(), hs.Hash()) {
+		log.Println(verify.Hash(), verify.Size(), hs.Hash(), hs.Size())
+		panic("compression CLAIMED it succeeded but decompressed to DIFFERENT DATA this is VERY BAD")
+	}
 }

--- a/crypto/db.go
+++ b/crypto/db.go
@@ -54,11 +54,10 @@ func DecryptDatabaseV2(data []byte, dbKey []byte) []byte {
 	decr := make([]byte, len(data)-16)
 	createCipherStream(iv, dbKey).XORKeyStream(decr, data[16:])
 	msg := decr[:len(decr)-32]
-	msgHash := sha256.New()
-	msgHash.Write(msg)
-	expectedMAC := ComputeMAC(msgHash.Sum(nil), dbKey)
+	msgHash := sha256.Sum256(msg)
+	expectedMAC := ComputeMAC(msgHash[:], dbKey)
 	if !bytes.Equal(expectedMAC, decr[len(decr)-32:]) {
-		panic("wrong mac")
+		panic("mac did not match. this means the database backup is corrupted or modified and cannot be decrypted")
 	}
 	return msg
 }

--- a/crypto/db.go
+++ b/crypto/db.go
@@ -1,11 +1,15 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"io"
 )
 
-func EncryptDatabase(data []byte, key []byte) []byte {
+func LegacyEncryptDatabase(data []byte, key []byte) []byte {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		panic(err)
@@ -18,7 +22,7 @@ func EncryptDatabase(data []byte, key []byte) []byte {
 	return gcm.Seal(nonce, nonce, data, nil)
 }
 
-func DecryptDatabase(data []byte, key []byte) []byte {
+func LegacyDecryptDatabase(data []byte, key []byte) []byte {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		panic(err)
@@ -33,4 +37,34 @@ func DecryptDatabase(data []byte, key []byte) []byte {
 		panic(err)
 	}
 	return plaintext
+}
+
+func EncryptDatabaseV2(out io.Writer, dbKey []byte) io.Writer {
+	iv := RandBytes(16)
+	_, err := out.Write(iv)
+	if err != nil {
+		panic(err)
+	}
+	return &cipher.StreamWriter{S: createCipherStream(iv, dbKey), W: out}
+}
+
+// lazy buffer for now - need to peel the last 32 bytes off, which is super annoying to do on an io.Reader of unknown length!
+func DecryptDatabaseV2(data []byte, dbKey []byte) []byte {
+	iv := data[:16]
+	decr := make([]byte, len(data)-16)
+	createCipherStream(iv, dbKey).XORKeyStream(decr, data[16:])
+	msg := decr[:len(decr)-32]
+	msgHash := sha256.New()
+	msgHash.Write(msg)
+	expectedMAC := ComputeMAC(msgHash.Sum(nil), dbKey)
+	if !bytes.Equal(expectedMAC, decr[len(decr)-32:]) {
+		panic("wrong mac")
+	}
+	return msg
+}
+
+func ComputeMAC(messageHash []byte, key []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(messageHash)
+	return mac.Sum(nil)
 }

--- a/crypto/db_test.go
+++ b/crypto/db_test.go
@@ -37,7 +37,7 @@ func TestV2Enc(t *testing.T) {
 	}
 
 	enc := buf.Bytes()
-	if len(enc) != len(data)+16+32 {
+	if len(enc) != 16+len(data)+32 {
 		t.Error("wrong length")
 	}
 

--- a/crypto/db_test.go
+++ b/crypto/db_test.go
@@ -3,14 +3,46 @@ package crypto
 import (
 	"bytes"
 	"testing"
+
+	"github.com/leijurv/gb/utils"
 )
 
 func TestEnc(t *testing.T) {
 	data := RandBytes(5021)
 	key := RandBytes(16)
-	enc := EncryptDatabase(data, key)
-	dec := DecryptDatabase(enc, key)
+	enc := LegacyEncryptDatabase(data, key)
+	dec := LegacyDecryptDatabase(enc, key)
 	if !bytes.Equal(dec, data) {
 		t.Error("Unequal")
+	}
+}
+
+func TestV2Enc(t *testing.T) {
+	data := RandBytes(5021)
+	key := RandBytes(16)
+	rawDB := utils.NewSHA256HasherSizer()
+	var buf bytes.Buffer
+	out := EncryptDatabaseV2(&buf, key)
+	_, err := out.Write(data)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = rawDB.Write(data)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = out.Write(ComputeMAC(rawDB.Hash(), key))
+	if err != nil {
+		t.Error(err)
+	}
+
+	enc := buf.Bytes()
+	if len(enc) != len(data)+16+32 {
+		t.Error("wrong length")
+	}
+
+	decr := DecryptDatabaseV2(enc, key)
+	if !bytes.Equal(decr, data) {
+		t.Error("unequal")
 	}
 }

--- a/storage_base/defs.go
+++ b/storage_base/defs.go
@@ -7,9 +7,8 @@ import (
 // a place where blobs can be stored
 type Storage interface {
 	BeginBlobUpload(blobID []byte) StorageUpload
+	BeginDatabaseUpload(filename string) StorageUpload
 	DownloadSection(path string, offset int64, length int64) io.ReadCloser
-
-	UploadDatabaseBackup(encryptedDatabase []byte, name string)
 
 	// it is like always faster to get a large list of path, checksum, size than to do it one file at a time
 	ListBlobs() []UploadedBlob


### PR DESCRIPTION
Should fix #30 @cwarden

I decided to just make a "v2" of database backup since GCM was too annoying. A simple SHA256 HMAC will do. This approach retains the property that the streaming, hashing, compression, etc is all CPU accelerated (there's x86_64 and arm64 assembly in the Go standard library for both AES-CTR and SHA256). I also like continuing to use AES-CTR and SHA256 since all of the rest of `gb` relies on them too.