### PR TITLE
Panic With Invalid Modification Time

### DIFF
--- a/backup/uploader.go
+++ b/backup/uploader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -182,7 +183,11 @@ func fileHasKnownData(tx *sql.Tx, path string, info os.FileInfo, hash []byte) {
 	if err != nil {
 		panic(err)
 	}
-	_, err = tx.Exec("INSERT INTO files (path, hash, start, fs_modified, permissions) VALUES (?, ?, ?, ?, ?)", path, hash, now, info.ModTime().Unix(), info.Mode()&os.ModePerm)
+	modTime := info.ModTime().Unix()
+	if modTime < 0 {
+		panic(fmt.Sprintf("Invalid modification time for %s: %d", path, modTime))
+	}
+	_, err = tx.Exec("INSERT INTO files (path, hash, start, fs_modified, permissions) VALUES (?, ?, ?, ?, ?)", path, hash, now, modTime, info.Mode()&os.ModePerm)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
If a file has a modification time before the unix epoch, insertion into
the files table will fail due to the CHECK constraint on fs_modified.

Check for an invalid modification time before trying to insert so we can
panic with a useful error containing the filename and modification time
instead of a generic "CHECK constraint failed: files" error.

Resolves #36
